### PR TITLE
hiera.yaml updated to use OS and major release

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,49 +6,12 @@ defaults:  # Used for any hierarchy level that omits these keys.
   data_hash: yaml_data  # Use the built-in YAML backend.
 
 hierarchy:
-  - name: "CentOS 7 Benchmark"
+  - name: "OS Benchmark Params"
     paths:
-      - "cis/cis_centos_7_params.yaml"
-      - "cis/cis_centos_7_rules.yaml"
-  - name: "Redhat 7 Benchmark"
+      - "cis/cis_%{facts.os.name}_%{facts.os.release.major}_params.yaml"
+  - name: "OS Benchmark Rules"
     paths:
-      - "cis/cis_redhat_7_params.yaml"
-      - "cis/cis_redhat_7_rules.yaml"
-  - name: "AlmaLinux 8 Benchmark"
-    paths:
-      - "cis/cis_almalinux_8_params.yaml"
-      - "cis/cis_almalinux_8_rules.yaml"
-  - name: "Rocky 8 Benchmark"
-    paths:
-      - "cis/cis_rocky_8_params.yaml"
-      - "cis/cis_rocky_8_rules.yaml"
-  - name: "Redhat 8 Benchmark"
-    paths:
-      - "cis/cis_redhat_8_params.yaml"
-      - "cis/cis_redhat_8_rules.yaml"
-  - name: "Ubuntu 18.04 Benchmark"
-    paths:
-      - "cis/cis_ubuntu_18.04_params.yaml"
-      - "cis/cis_ubuntu_18.04_rules.yaml"
-  - name: "Ubuntu 20.04 Benchmark"
-    paths:
-      - "cis/cis_ubuntu_20.04_params.yaml"
-      - "cis/cis_ubuntu_20.04_rules.yaml"
-  - name: "Ubuntu 20.04 STIG Benchmark"
-    paths:
-      - "stig/cis_ubuntu_20.04_params.yaml"
-      - "stig/cis_ubuntu_20.04_rules.yaml"
-  - name: "Debian 10 Benchmark"
-    paths:
-      - "cis/cis_debian_10_params.yaml"
-      - "cis/cis_debian_10_rules.yaml"
-  - name: 'SLES 12 Benchmark'
-    paths:
-      - "cis/cis_sles_12_params.yaml"
-      - "cis/cis_sles_12_rules.yaml"
-  - name: 'SLES 15 Benchmark'
-    paths:
-      - "cis/cis_sles_15_params.yaml"
-      - "cis/cis_sles_15_rules.yaml"
+      - "cis/cis_%{facts.os.name}_%{facts.os.release.major}_rules.yaml"
+  
   - name: 'common definitions'
     path: 'common.yaml'


### PR DESCRIPTION
I have updated hiera.yaml to use the OS name and renamed the hiera data files in data/cis to reflect what facter returns.  I don't know all of the exact names for every Linux you support but have completed RedHat, AlmaLinux, CentOS and Ubuntu.