### PR TITLE
hiera data for grub password to several distros

### DIFF
--- a/data/cis/cis_almalinux_8_params.yaml
+++ b/data/cis/cis_almalinux_8_params.yaml
@@ -1,3 +1,4 @@
+
 ---
 cis_security_hardening::profile: server
 cis_security_hardening::level: '2'
@@ -58,6 +59,7 @@ cis_security_hardening::rules::aide_installed::enforce: true
 cis_security_hardening::rules::aide_regular_checks::enforce: true
 
 cis_security_hardening::rules::grub_password::enforce: false
+cis_security_hardening::rules::grub_password::grub_password_pbkdf2: 'xxx'
 cis_security_hardening::rules::grub_bootloader_config::enforce: true
 cis_security_hardening::rules::single_user_mode::enforce: true
 

--- a/data/cis/cis_centos_7_params.yaml
+++ b/data/cis/cis_centos_7_params.yaml
@@ -47,6 +47,7 @@ cis_security_hardening::rules::aide_installed::enforce: true
 cis_security_hardening::rules::aide_regular_checks::enforce: true
 
 cis_security_hardening::rules::grub_password::enforce: false
+cis_security_hardening::rules::grub_password::grub_password_pbkdf2: 'xxx'
 cis_security_hardening::rules::grub_bootloader_config::enforce: true
 cis_security_hardening::rules::single_user_mode::enforce: true
 

--- a/data/cis/cis_centos_8_params.yaml
+++ b/data/cis/cis_centos_8_params.yaml
@@ -58,6 +58,7 @@ cis_security_hardening::rules::aide_installed::enforce: true
 cis_security_hardening::rules::aide_regular_checks::enforce: true
 
 cis_security_hardening::rules::grub_password::enforce: false
+cis_security_hardening::rules::grub_password::grub_password_pbkdf2: 'xxx'
 cis_security_hardening::rules::grub_bootloader_config::enforce: true
 cis_security_hardening::rules::single_user_mode::enforce: true
 

--- a/data/cis/cis_redhat_7_params.yaml
+++ b/data/cis/cis_redhat_7_params.yaml
@@ -44,6 +44,7 @@ cis_security_hardening::rules::aide_installed::enforce: true
 cis_security_hardening::rules::aide_regular_checks::enforce: true
 
 cis_security_hardening::rules::grub_password::enforce: false
+cis_security_hardening::rules::grub_password::grub_password_pbkdf2: 'xxx'
 cis_security_hardening::rules::grub_bootloader_config::enforce: true
 cis_security_hardening::rules::single_user_mode::enforce: true
 

--- a/data/cis/cis_redhat_8_params.yaml
+++ b/data/cis/cis_redhat_8_params.yaml
@@ -58,6 +58,7 @@ cis_security_hardening::rules::aide_installed::enforce: true
 cis_security_hardening::rules::aide_regular_checks::enforce: true
 
 cis_security_hardening::rules::grub_password::enforce: false
+cis_security_hardening::rules::grub_password::grub_password_pbkdf2: 'xxx'
 cis_security_hardening::rules::grub_bootloader_config::enforce: true
 cis_security_hardening::rules::single_user_mode::enforce: true
 

--- a/data/cis/cis_rocky_8_params.yaml
+++ b/data/cis/cis_rocky_8_params.yaml
@@ -58,6 +58,7 @@ cis_security_hardening::rules::aide_installed::enforce: true
 cis_security_hardening::rules::aide_regular_checks::enforce: true
 
 cis_security_hardening::rules::grub_password::enforce: false
+cis_security_hardening::rules::grub_password::grub_password_pbkdf2: 'xxx'
 cis_security_hardening::rules::grub_bootloader_config::enforce: true
 cis_security_hardening::rules::single_user_mode::enforce: true
 


### PR DESCRIPTION
added grub password hiera data to params for Red Hat, Alma Linux, CentOS and Rocky