### PR TITLE
Fix facts usage etc

### DIFF
--- a/data/cis/cis_AlmaLinux_8_params.yaml
+++ b/data/cis/cis_AlmaLinux_8_params.yaml
@@ -117,13 +117,9 @@ cis_security_hardening::rules::xinetd::enforce: true
 cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: chrony
 cis_security_hardening::rules::chrony::enforce: true
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::ntpd::enforce: false
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_CentOS_7_params.yaml
+++ b/data/cis/cis_CentOS_7_params.yaml
@@ -98,13 +98,13 @@ cis_security_hardening::rules::xinetd::enforce: true
 cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: ntp
 cis_security_hardening::rules::chrony::enforce: false
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
+#  10.10.10.10: []
+#  10.10.10.11: []
 cis_security_hardening::rules::ntpd::enforce: true
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
+#  - 10.10.10.1
+#  - 10.10.10.11
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_CentOS_7_params.yaml
+++ b/data/cis/cis_CentOS_7_params.yaml
@@ -99,12 +99,8 @@ cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: ntp
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~
-#  10.10.10.10: []
-#  10.10.10.11: []
 cis_security_hardening::rules::ntpd::enforce: true
 cis_security_hardening::rules::ntpd::ntp_servers: ~
-#  - 10.10.10.1
-#  - 10.10.10.11
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_CentOS_8_params.yaml
+++ b/data/cis/cis_CentOS_8_params.yaml
@@ -116,13 +116,13 @@ cis_security_hardening::rules::xinetd::enforce: true
 cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: chrony
 cis_security_hardening::rules::chrony::enforce: true
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
+#  10.10.10.10: []
+#  10.10.10.11: []
 cis_security_hardening::rules::ntpd::enforce: false
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
+#  - 10.10.10.1
+#  - 10.10.10.11
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_CentOS_8_params.yaml
+++ b/data/cis/cis_CentOS_8_params.yaml
@@ -117,12 +117,8 @@ cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: chrony
 cis_security_hardening::rules::chrony::enforce: true
 cis_security_hardening::rules::chrony::ntp_servers: ~
-#  10.10.10.10: []
-#  10.10.10.11: []
 cis_security_hardening::rules::ntpd::enforce: false
 cis_security_hardening::rules::ntpd::ntp_servers: ~
-#  - 10.10.10.1
-#  - 10.10.10.11
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_Debian_10_params.yaml
+++ b/data/cis/cis_Debian_10_params.yaml
@@ -89,13 +89,9 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
 cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::ntpd::enforce: true
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - '-4 default kod nomodify notrap nopeer noquery'
   - '-6 default kod nomodify notrap nopeer noquery'

--- a/data/cis/cis_RedHat_7_params.yaml
+++ b/data/cis/cis_RedHat_7_params.yaml
@@ -124,13 +124,9 @@ cis_security_hardening::rules::xinetd::enforce: true
 cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: ntp
 cis_security_hardening::rules::chrony::enforce: false
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::ntpd::enforce: true
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_RedHat_8_params.yaml
+++ b/data/cis/cis_RedHat_8_params.yaml
@@ -155,9 +155,7 @@ cis_security_hardening::rules::xinetd::enforce: true
 cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: chrony
 cis_security_hardening::rules::chrony::enforce: true
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 
 cis_security_hardening::rules::x11_installed::enforce: true
 cis_security_hardening::rules::avahi::enforce: true

--- a/data/cis/cis_Rocky_8_params.yaml
+++ b/data/cis/cis_Rocky_8_params.yaml
@@ -116,13 +116,9 @@ cis_security_hardening::rules::xinetd::enforce: true
 cis_security_hardening::rules::ntp_package::enforce: true
 cis_security_hardening::rules::ntp_package::pkg: chrony
 cis_security_hardening::rules::chrony::enforce: true
-cis_security_hardening::rules::chrony::ntp_servers:
-  - hostname: 10.10.10.10
-  - hostname: 10.10.10.11
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::ntpd::enforce: false
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_SLES_12_params.yaml
+++ b/data/cis/cis_SLES_12_params.yaml
@@ -95,13 +95,9 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
 cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: true
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::ntpd::enforce: true
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - 127.0.0.1
 cis_security_hardening::rules::ntpd::ntp_driftfile: ''

--- a/data/cis/cis_SLES_15_params.yaml
+++ b/data/cis/cis_SLES_15_params.yaml
@@ -96,9 +96,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
 cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::x11_installed::enforce: true
 cis_security_hardening::rules::avahi::enforce: true
 cis_security_hardening::rules::cups::enforce: true

--- a/data/cis/cis_Ubuntu_18.04_params.yaml
+++ b/data/cis/cis_Ubuntu_18.04_params.yaml
@@ -88,13 +88,9 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
 cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::ntpd::enforce: true
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - '-4 default kod nomodify notrap nopeer noquery'
   - '-6 default kod nomodify notrap nopeer noquery'

--- a/data/cis/cis_Ubuntu_20.04_params.yaml
+++ b/data/cis/cis_Ubuntu_20.04_params.yaml
@@ -101,15 +101,11 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
 cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
-cis_security_hardening::rules::chrony::ntp_servers:
-  10.10.10.10: []
-  10.10.10.11: []
+cis_security_hardening::rules::chrony::ntp_servers: ~
 cis_security_hardening::rules::chrony::makestep_seconds: 1
 cis_security_hardening::rules::chrony::makestep_updates: 3
 cis_security_hardening::rules::ntpd::enforce: true
-cis_security_hardening::rules::ntpd::ntp_servers:
-  - 10.10.10.1
-  - 10.10.10.11
+cis_security_hardening::rules::ntpd::ntp_servers: ~
 cis_security_hardening::rules::ntpd::ntp_restrict:
   - '-4 default kod nomodify notrap nopeer noquery'
   - '-6 default kod nomodify notrap nopeer noquery'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,7 @@ class cis_security_hardening (
   Boolean $remove_authconfig                = false,
 ) {
   contain cis_security_hardening::reboot
+  contain cis_security_hardening::services
 
   $base_dir = '/usr/share/cis_security_hardening'
 
@@ -60,10 +61,6 @@ class cis_security_hardening (
     ensure_packages(['authconfig'], {
         ensure => $ensure,
     })
-  }
-
-  class { 'cis_security_hardening::services':
-    time_until_reboot => $time_until_reboot,
   }
 
   class { 'cis_security_hardening::sticky_world_writable_cron':

--- a/manifests/rules/auditd_privileged_commands.pp
+++ b/manifests/rules/auditd_privileged_commands.pp
@@ -10,8 +10,6 @@
 #
 # @param enforce
 #    Sets rule enforcement. If set to true, code will be exeuted to bring the system into a comliant state.
-# @param auto_reboot
-#    Trigger a reboot if this rule creates a change. Defaults to true.
 #
 # @example
 #   class { 'cis_security_hardening::rules::auditd_privileged_commands':
@@ -21,7 +19,6 @@
 # @api private
 class cis_security_hardening::rules::auditd_privileged_commands (
   Boolean $enforce                 = false,
-  Boolean $auto_reboot             = true,
 ) {
   if $enforce {
     $dir = dirname($cis_security_hardening::rules::auditd_init::rules_file)

--- a/manifests/rules/chrony.pp
+++ b/manifests/rules/chrony.pp
@@ -23,7 +23,7 @@
 #    Limit of clock updates since chronyd start.
 #
 # @example
-#   class ecurity_baseline::rules::common::sec_ntp_daemon_chrony {
+#   class cis_security_hardening::rules::chrony {
 #       enforce => true,
 #       ntp_servers => ['server1', 'server2'],
 #     }
@@ -31,12 +31,16 @@
 #
 # @api private
 class cis_security_hardening::rules::chrony (
-  Boolean $enforce   = false,
-  Hash $ntp_servers = {},
-  Integer $makestep_seconds = 1,
-  Integer $makestep_updates = 3,
+  Boolean $enforce            = false,
+  Optional[Hash] $ntp_servers = {},
+  Integer $makestep_seconds   = 1,
+  Integer $makestep_updates   = 3,
 ) {
   if $enforce {
+    if(empty($ntp_servers)) {
+      warning("You have not defined any ntp servers, time updating may not work unless provided by your network DHCP")
+    }
+
     class { 'chrony':
       servers          => $ntp_servers,
       makestep_seconds => $makestep_seconds,

--- a/manifests/rules/chrony.pp
+++ b/manifests/rules/chrony.pp
@@ -37,8 +37,12 @@ class cis_security_hardening::rules::chrony (
   Integer $makestep_updates   = 3,
 ) {
   if $enforce {
-    if(empty($ntp_servers)) {
-      warning("You have not defined any ntp servers, time updating may not work unless provided by your network DHCP")
+    if (empty($ntp_servers)) {
+      echo { 'no ntp servers warning':
+        message  => 'You have not defined any ntp servers, time updating may not work unless provided by your network DHCP',
+        loglevel => 'warning',
+        withpath => false,
+      }
     }
 
     class { 'chrony':

--- a/manifests/rules/cramfs.pp
+++ b/manifests/rules/cramfs.pp
@@ -28,7 +28,7 @@ class cis_security_hardening::rules::cramfs (
         }
         kmod::blacklist { 'cramfs': }
       }
-      'redhat': {
+      'centos', 'redhat': {
         if $facts['os']['release']['major'] > '7' {
           kmod::install { 'cramfs':
             command => '/bin/false',

--- a/manifests/rules/ntpd.pp
+++ b/manifests/rules/ntpd.pp
@@ -55,8 +55,12 @@ class cis_security_hardening::rules::ntpd (
 ) {
   if $enforce and
   $facts['operatingsystem'].downcase() != 'sles' {
-    if(empty($ntp_servers)) {
-      warning("You have not defined any ntp servers, time updating may not work unless provided by your network DHCP")
+    if (empty($ntp_servers)) {
+      echo { 'no ntp servers warning':
+        message  => 'You have not defined any ntp servers, time updating may not work unless provided by your network DHCP',
+        loglevel => 'warning',
+        withpath => false,
+      }
     }
     $ntp_default = {
       servers         => $ntp_servers,

--- a/manifests/rules/ntpd.pp
+++ b/manifests/rules/ntpd.pp
@@ -45,7 +45,7 @@
 # @api private
 class cis_security_hardening::rules::ntpd (
   Boolean $enforce             = false,
-  Array $ntp_servers           = [],
+  Optional[Array] $ntp_servers = [],
   Array $ntp_restrict          = [],
   String $ntp_driftfile        = '',
   String $ntp_statsdir         = '',
@@ -53,10 +53,10 @@ class cis_security_hardening::rules::ntpd (
   Boolean $ntp_burst           = false,
   Boolean $ntp_service_manage  = true,
 ) {
-  if  $enforce and
+  if $enforce and
   $facts['operatingsystem'].downcase() != 'sles' {
     if(empty($ntp_servers)) {
-      fail("Can't configure ntp daemon without ntp servers")
+      warning("You have not defined any ntp servers, time updating may not work unless provided by your network DHCP")
     }
     $ntp_default = {
       servers         => $ntp_servers,

--- a/manifests/rules/selinux_state.pp
+++ b/manifests/rules/selinux_state.pp
@@ -48,5 +48,11 @@ class cis_security_hardening::rules::selinux_state (
       multiple => true,
       notify   => $notify,
     }
+
+    # Ensure selinux is active in event of disabling, as config files require reboot
+    exec { 'ensure selinux active':
+      command => '/usr/sbin/setenforce 1',
+      unless  => '/usr/sbin/getenforce | grep Enforcing'
+    }
   }
 }

--- a/manifests/rules/squashfs.pp
+++ b/manifests/rules/squashfs.pp
@@ -29,7 +29,7 @@ class cis_security_hardening::rules::squashfs (
         }
         kmod::blacklist { 'squashfs': }
       }
-      'redhat': {
+      'centos', 'redhat': {
         if $facts['operatingsystemmajrelease'] > '7' {
           kmod::install { 'squashfs':
             command => '/bin/false',

--- a/manifests/rules/udf.pp
+++ b/manifests/rules/udf.pp
@@ -30,7 +30,7 @@ class cis_security_hardening::rules::udf (
         }
         kmod::blacklist { 'udf': }
       }
-      'redhat': {
+      'centos', 'redhat': {
         if $facts['operatingsystemmajrelease'] > '7' {
           kmod::install { 'udf':
             command => '/bin/false',

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -8,9 +8,7 @@
 #
 # @example
 #   include cis_security_hardening::services
-class cis_security_hardening::services (
-  Integer $time_until_reboot = 60,
-) {
+class cis_security_hardening::services {
   $rel = fact('os') ? {
     undef   => '',
     default => fact('operatingsystemmajrelease')
@@ -87,10 +85,4 @@ class cis_security_hardening::services (
     path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
     refreshonly => true,
   }
-
-  # reboot { 'after_run':
-  #   timeout => $time_until_reboot,
-  #   message => 'forced reboot by Puppet',
-  #   apply   => 'finished',
-  # }
 }

--- a/spec/classes/rules/chrony_spec.rb
+++ b/spec/classes/rules/chrony_spec.rb
@@ -8,7 +8,6 @@ describe 'cis_security_hardening::rules::chrony' do
   on_supported_os.each do |os, os_facts|
     enforce_options.each do |enforce|
       context "on #{os}" do
-
         describe 'without ntp servers defined' do
           let(:facts) { os_facts }
           let(:params) do
@@ -38,10 +37,10 @@ describe 'cis_security_hardening::rules::chrony' do
               'makestep_updates' => -1,
             }
           end
-  
+
           it {
             is_expected.to compile
-  
+
             if enforce
               is_expected.to contain_class('chrony')
                 .with(
@@ -52,7 +51,7 @@ describe 'cis_security_hardening::rules::chrony' do
                   'makestep_seconds' => 1,
                   'makestep_updates' => -1,
                 )
-  
+
               if os_facts[:operatingsystem].casecmp('ubuntu').zero?
                 is_expected.to contain_package('ntp')
                   .with(
@@ -68,7 +67,7 @@ describe 'cis_security_hardening::rules::chrony' do
                     'mode'    => '0644',
                     'content' => 'OPTIONS="-u chrony"',
                   )
-  
+
               end
             else
               is_expected.not_to contain_class('chrony')

--- a/spec/classes/rules/chrony_spec.rb
+++ b/spec/classes/rules/chrony_spec.rb
@@ -8,56 +8,75 @@ describe 'cis_security_hardening::rules::chrony' do
   on_supported_os.each do |os, os_facts|
     enforce_options.each do |enforce|
       context "on #{os}" do
-        let(:facts) { os_facts }
-        let(:params) do
-          {
-            'enforce' => enforce,
-            'ntp_servers' => {
-              '10.10.10.1' => ['iburst', 'maxpoll 17'],
-              '10.10.10.2' => ['iburst', 'maxpoll 17'],
-            },
-            'makestep_seconds' => 1,
-            'makestep_updates' => -1,
-          }
+
+        describe 'without ntp servers defined' do
+          let(:facts) { os_facts }
+          let(:params) do
+            {
+              'enforce' => enforce,
+              'ntp_servers' => {},
+              'makestep_seconds' => 1,
+              'makestep_updates' => -1,
+            }
+          end
+
+          if enforce && !os_facts[:operatingsystem].casecmp('sles').zero?
+            it { is_expected.to create_echo('no ntp servers warning').with_message(%r{You have not defined any ntp servers, time updating may not work unless provided by your network DHCP}) }
+          end
         end
 
-        it {
-          is_expected.to compile
-
-          if enforce
-            is_expected.to contain_class('chrony')
-              .with(
-                'servers' => {
-                  '10.10.10.1' => ['iburst', 'maxpoll 17'],
-                  '10.10.10.2' => ['iburst', 'maxpoll 17'],
-                },
-                'makestep_seconds' => 1,
-                'makestep_updates' => -1,
-              )
-
-            if os_facts[:operatingsystem].casecmp('ubuntu').zero?
-              is_expected.to contain_package('ntp')
-                .with(
-                  'ensure' => 'purged',
-                )
-            elsif os_facts[:operatingsystem].casecmp('rocky').zero? || os_facts[:operatingsystem].casecmp('almalinux').zero? ||
-                  os_facts[:operatingsystem].casecmp('redhst').zero? || os_facts[:operatingsystem].casecmp('centos').zero?
-              is_expected.to contain_file('/etc/sysconfig/chronyd')
-                .with(
-                  'ensure'  => 'file',
-                  'owner'   => 'root',
-                  'group'   => 'root',
-                  'mode'    => '0644',
-                  'content' => 'OPTIONS="-u chrony"',
-                )
-
-            end
-          else
-            is_expected.not_to contain_class('chrony')
-            is_expected.not_to contain_package('ntp')
-            is_expected.not_to contain_file('/etc/sysconfig/chronyd')
+        describe 'with ntp servers defined' do
+          let(:facts) { os_facts }
+          let(:params) do
+            {
+              'enforce' => enforce,
+              'ntp_servers' => {
+                '10.10.10.1' => ['iburst', 'maxpoll 17'],
+                '10.10.10.2' => ['iburst', 'maxpoll 17'],
+              },
+              'makestep_seconds' => 1,
+              'makestep_updates' => -1,
+            }
           end
-        }
+  
+          it {
+            is_expected.to compile
+  
+            if enforce
+              is_expected.to contain_class('chrony')
+                .with(
+                  'servers' => {
+                    '10.10.10.1' => ['iburst', 'maxpoll 17'],
+                    '10.10.10.2' => ['iburst', 'maxpoll 17'],
+                  },
+                  'makestep_seconds' => 1,
+                  'makestep_updates' => -1,
+                )
+  
+              if os_facts[:operatingsystem].casecmp('ubuntu').zero?
+                is_expected.to contain_package('ntp')
+                  .with(
+                    'ensure' => 'purged',
+                  )
+              elsif os_facts[:operatingsystem].casecmp('rocky').zero? || os_facts[:operatingsystem].casecmp('almalinux').zero? ||
+                    os_facts[:operatingsystem].casecmp('redhst').zero? || os_facts[:operatingsystem].casecmp('centos').zero?
+                is_expected.to contain_file('/etc/sysconfig/chronyd')
+                  .with(
+                    'ensure'  => 'file',
+                    'owner'   => 'root',
+                    'group'   => 'root',
+                    'mode'    => '0644',
+                    'content' => 'OPTIONS="-u chrony"',
+                  )
+  
+              end
+            else
+              is_expected.not_to contain_class('chrony')
+              is_expected.not_to contain_package('ntp')
+              is_expected.not_to contain_file('/etc/sysconfig/chronyd')
+            end
+          }
+        end
       end
     end
   end

--- a/spec/classes/rules/cramfs_spec.rb
+++ b/spec/classes/rules/cramfs_spec.rb
@@ -24,7 +24,7 @@ describe 'cis_security_hardening::rules::cramfs' do
                   command: '/bin/false',
                 )
               is_expected.to contain_kmod__blacklist('cramfs')
-            elsif os_facts[:operatingsystem].casecmp('redhat').zero?
+            elsif os_facts[:operatingsystem].casecmp('redhat').zero? || os_facts[:operatingsystem].casecmp('centos').zero?
               if os_facts[:operatingsystemmajrelease] > '7'
                 is_expected.to contain_kmod__install('cramfs')
                   .with(

--- a/spec/classes/rules/ntpd_spec.rb
+++ b/spec/classes/rules/ntpd_spec.rb
@@ -8,68 +8,87 @@ describe 'cis_security_hardening::rules::ntpd' do
   on_supported_os.each do |os, os_facts|
     enforce_options.each do |enforce|
       context "on #{os} with enforce = #{enforce}" do
-        let(:facts) { os_facts }
-        let(:params) do
-          {
-            'enforce' => enforce,
-            'ntp_servers' => ['10.10.10.1', '10.10.10.2'],
-            'ntp_statsdir' => '/var/tmp',
-            'ntp_restrict' => ['127.0.0.1'],
-          }
-        end
 
-        it {
-          is_expected.to compile
+        describe 'without ntp servers defined' do
+          let(:facts) { os_facts }
+          let(:params) do
+            {
+              'enforce' => enforce,
+              'ntp_servers' => [],
+              'ntp_statsdir' => '/var/tmp',
+              'ntp_restrict' => ['127.0.0.1'],
+            }
+          end
 
           if enforce && !os_facts[:operatingsystem].casecmp('sles').zero?
-
-            is_expected.to create_class('ntp')
-              .with(
-                'servers' => ['10.10.10.1', '10.10.10.2'],
-                'restrict'        => ['127.0.0.1'],
-                'statsdir'        => '/var/tmp',
-                'disable_monitor' => true,
-                'iburst_enable'   => false,
-                'service_manage'  => true,
-              )
-
-            if os_facts[:osfamily].casecmp('debian').zero?
-              is_expected.to contain_package('chrony')
-                .with(
-                  'ensure' => 'purged',
-                )
-              is_expected.to contain_service('systemd-timesyncd')
-                .with(
-                  'ensure' => 'stopped',
-                  'enable' => false,
-                )
-
-              is_expected.to contain_file_line('ntp runas')
-                .with(
-                  'ensure' => 'present',
-                  'path'   => '/etc/init.d/ntp',
-                  'match'  => '^RUNASUSER=',
-                  'line'   =>  'RUNASUSER=ntp',
-                )
-
-            else
-              is_expected.not_to contain_service('systemd-timesyncd')
-              is_expected.to contain_file('/etc/sysconfig/ntpd')
-                .with(
-                  'ensure'  => 'file',
-                  'owner'   => 'root',
-                  'group'   => 'root',
-                  'mode'    => '0644',
-                  'content' => 'OPTIONS="-u ntp:ntp"',
-                )
-            end
-          else
-            is_expected.not_to create_class('ntp')
-            is_expected.not_to contain_file('/etc/sysconfig/ntpd')
-            is_expected.not_to contain_package('chrony')
-            is_expected.not_to contain_service('systemd-timesyncd')
+            it { is_expected.to create_echo('no ntp servers warning').with_message(%r{You have not defined any ntp servers, time updating may not work unless provided by your network DHCP}) }
           end
-        }
+        end
+
+        describe 'with ntp servers defined' do
+          let(:facts) { os_facts }
+          let(:params) do
+            {
+              'enforce' => enforce,
+              'ntp_servers' => ['10.10.10.1', '10.10.10.2'],
+              'ntp_statsdir' => '/var/tmp',
+              'ntp_restrict' => ['127.0.0.1'],
+            }
+          end
+  
+          it {
+            is_expected.to compile
+  
+            if enforce && !os_facts[:operatingsystem].casecmp('sles').zero?
+  
+              is_expected.to create_class('ntp')
+                .with(
+                  'servers' => ['10.10.10.1', '10.10.10.2'],
+                  'restrict'        => ['127.0.0.1'],
+                  'statsdir'        => '/var/tmp',
+                  'disable_monitor' => true,
+                  'iburst_enable'   => false,
+                  'service_manage'  => true,
+                )
+  
+              if os_facts[:osfamily].casecmp('debian').zero?
+                is_expected.to contain_package('chrony')
+                  .with(
+                    'ensure' => 'purged',
+                  )
+                is_expected.to contain_service('systemd-timesyncd')
+                  .with(
+                    'ensure' => 'stopped',
+                    'enable' => false,
+                  )
+  
+                is_expected.to contain_file_line('ntp runas')
+                  .with(
+                    'ensure' => 'present',
+                    'path'   => '/etc/init.d/ntp',
+                    'match'  => '^RUNASUSER=',
+                    'line'   =>  'RUNASUSER=ntp',
+                  )
+  
+              else
+                is_expected.not_to contain_service('systemd-timesyncd')
+                is_expected.to contain_file('/etc/sysconfig/ntpd')
+                  .with(
+                    'ensure'  => 'file',
+                    'owner'   => 'root',
+                    'group'   => 'root',
+                    'mode'    => '0644',
+                    'content' => 'OPTIONS="-u ntp:ntp"',
+                  )
+              end
+            else
+              is_expected.not_to create_class('ntp')
+              is_expected.not_to contain_file('/etc/sysconfig/ntpd')
+              is_expected.not_to contain_package('chrony')
+              is_expected.not_to contain_service('systemd-timesyncd')
+            end
+          }
+        end
       end
     end
   end

--- a/spec/classes/rules/ntpd_spec.rb
+++ b/spec/classes/rules/ntpd_spec.rb
@@ -8,7 +8,6 @@ describe 'cis_security_hardening::rules::ntpd' do
   on_supported_os.each do |os, os_facts|
     enforce_options.each do |enforce|
       context "on #{os} with enforce = #{enforce}" do
-
         describe 'without ntp servers defined' do
           let(:facts) { os_facts }
           let(:params) do
@@ -35,12 +34,12 @@ describe 'cis_security_hardening::rules::ntpd' do
               'ntp_restrict' => ['127.0.0.1'],
             }
           end
-  
+
           it {
             is_expected.to compile
-  
+
             if enforce && !os_facts[:operatingsystem].casecmp('sles').zero?
-  
+
               is_expected.to create_class('ntp')
                 .with(
                   'servers' => ['10.10.10.1', '10.10.10.2'],
@@ -50,7 +49,7 @@ describe 'cis_security_hardening::rules::ntpd' do
                   'iburst_enable'   => false,
                   'service_manage'  => true,
                 )
-  
+
               if os_facts[:osfamily].casecmp('debian').zero?
                 is_expected.to contain_package('chrony')
                   .with(
@@ -61,7 +60,7 @@ describe 'cis_security_hardening::rules::ntpd' do
                     'ensure' => 'stopped',
                     'enable' => false,
                   )
-  
+
                 is_expected.to contain_file_line('ntp runas')
                   .with(
                     'ensure' => 'present',
@@ -69,7 +68,7 @@ describe 'cis_security_hardening::rules::ntpd' do
                     'match'  => '^RUNASUSER=',
                     'line'   =>  'RUNASUSER=ntp',
                   )
-  
+
               else
                 is_expected.not_to contain_service('systemd-timesyncd')
                 is_expected.to contain_file('/etc/sysconfig/ntpd')

--- a/spec/classes/rules/squashfs_spec.rb
+++ b/spec/classes/rules/squashfs_spec.rb
@@ -24,7 +24,7 @@ describe 'cis_security_hardening::rules::squashfs' do
                   command: '/bin/false',
                 )
               is_expected.to contain_kmod__blacklist('squashfs')
-            elsif os_facts[:operatingsystem].casecmp('redhat').zero?
+            elsif os_facts[:operatingsystem].casecmp('redhat').zero? || os_facts[:operatingsystem].casecmp('centos').zero?
               if os_facts[:operatingsystemmajrelease] > '7'
                 is_expected.to contain_kmod__install('squashfs')
                   .with(

--- a/spec/classes/rules/udf_spec.rb
+++ b/spec/classes/rules/udf_spec.rb
@@ -24,7 +24,7 @@ describe 'cis_security_hardening::rules::udf' do
                   command: '/bin/false',
                 )
               is_expected.to contain_kmod__blacklist('udf')
-            elsif os_facts[:operatingsystem].casecmp('redhat').zero?
+            elsif os_facts[:operatingsystem].casecmp('redhat').zero? || os_facts[:operatingsystem].casecmp('centos').zero?
               if os_facts[:operatingsystemmajrelease] > '7'
                 is_expected.to contain_kmod__install('udf')
                   .with(


### PR DESCRIPTION
1. Fix facts not resolving CentOS is 3 classes
2. Make NTP servers optional and raise warning if not provided, also remove hardcoded default ones