### PR TITLE
Added functionality to enable specifying the sshd PermitRootLogin level

### DIFF
--- a/data/cis/cis_AlmaLinux_8_params.yaml
+++ b/data/cis/cis_AlmaLinux_8_params.yaml
@@ -396,6 +396,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_CentOS_7_params.yaml
+++ b/data/cis/cis_CentOS_7_params.yaml
@@ -366,6 +366,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true
 cis_security_hardening::rules::sshd_ciphers::ciphers:

--- a/data/cis/cis_CentOS_8_params.yaml
+++ b/data/cis/cis_CentOS_8_params.yaml
@@ -395,6 +395,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_Debian_10_params.yaml
+++ b/data/cis/cis_Debian_10_params.yaml
@@ -364,6 +364,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_RedHat_7_params.yaml
+++ b/data/cis/cis_RedHat_7_params.yaml
@@ -439,6 +439,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true
 cis_security_hardening::rules::sshd_ciphers::ciphers:

--- a/data/cis/cis_RedHat_8_params.yaml
+++ b/data/cis/cis_RedHat_8_params.yaml
@@ -113,7 +113,6 @@ cis_security_hardening::rules::policycoreutils::enforce: true
 
 cis_security_hardening::rules::motd_perms::enforce: true
 cis_security_hardening::rules::motd_perms::content: |
-  
   ###################################################################
   # This system is for the use of authorized users only.            #
   # Individuals using this computer system without authority, or in #
@@ -131,11 +130,12 @@ cis_security_hardening::rules::motd_perms::content: |
   # evidence of such monitoring to law enforcement officials.       #
   ###################################################################
   
-
 cis_security_hardening::rules::issue_perms::enforce: true
 cis_security_hardening::rules::issue_perms::content: ''
+
 cis_security_hardening::rules::issue_net_perms::enforce: true
 cis_security_hardening::rules::issue_net_perms::content: ''
+
 cis_security_hardening::rules::gnome_gdm::enforce: true
 cis_security_hardening::rules::gnome_gdm_package::enforce: true
 cis_security_hardening::rules::xdmcp_config::enforce: true
@@ -505,6 +505,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_Rocky_8_params.yaml
+++ b/data/cis/cis_Rocky_8_params.yaml
@@ -395,6 +395,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_SLES_12_params.yaml
+++ b/data/cis/cis_SLES_12_params.yaml
@@ -317,6 +317,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_SLES_15_params.yaml
+++ b/data/cis/cis_SLES_15_params.yaml
@@ -351,6 +351,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_Ubuntu_18.04_params.yaml
+++ b/data/cis/cis_Ubuntu_18.04_params.yaml
@@ -363,6 +363,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/data/cis/cis_Ubuntu_20.04_params.yaml
+++ b/data/cis/cis_Ubuntu_20.04_params.yaml
@@ -444,6 +444,7 @@ cis_security_hardening::rules::sshd_max_auth_tries::max_auth_tries: 4
 cis_security_hardening::rules::sshd_ignore_rhosts::enforce: true
 cis_security_hardening::rules::sshd_hostbased_authentication::enforce: true
 cis_security_hardening::rules::sshd_root_login::enforce: true
+cis_security_hardening::rules::sshd_root_login::permitrootlogin: no
 cis_security_hardening::rules::sshd_empty_passwords::enforce: true
 cis_security_hardening::rules::sshd_user_environment::enforce: true
 cis_security_hardening::rules::sshd_ciphers::enforce: true

--- a/manifests/rules/sshd_root_login.pp
+++ b/manifests/rules/sshd_root_login.pp
@@ -19,6 +19,7 @@
 # @api private
 class cis_security_hardening::rules::sshd_root_login (
   Boolean $enforce = false,
+  Cis_security_hardening::Sshd_root_login_values $permitrootlogin = 'no',
 ) {
   if $enforce {
     $path = ($facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12') ? {
@@ -28,7 +29,7 @@ class cis_security_hardening::rules::sshd_root_login (
     file_line { 'sshd-root-login':
       ensure => present,
       path   => $path,
-      line   => 'PermitRootLogin no',
+      line   => "PermitRootLogin ${permitrootlogin}",
       match  => '^#?PermitRootLogin.*',
       notify => Exec['reload-sshd'],
     }

--- a/spec/classes/rules/sshd_root_login_spec.rb
+++ b/spec/classes/rules/sshd_root_login_spec.rb
@@ -62,6 +62,7 @@ describe 'cis_security_hardening::rules::sshd_root_login' do
         let(:params) do
           {
             'enforce' => enforce,
+            'permitrootlogin' => 'no',
           }
         end
 

--- a/types/sshd_root_login_values.pp
+++ b/types/sshd_root_login_values.pp
@@ -1,0 +1,4 @@
+# @summary Valid sshd PermitRootLogin values
+#
+
+type Cis_security_hardening::Sshd_root_login_values = Enum['yes', 'prohibit-password', 'without-password', 'forced-commands-only', 'no']


### PR DESCRIPTION
The sshd parameter PermitRootLog is set to no in the CIS rules.  I have added the ability to specify to all valid options (yes, prohibit-password, without-password, forced-commands-only, no) included a type checker to ensure valid input.
This is common relaxation of CIS rules to allow ssh login by root using public key but enables the user to choose the level desired.