### PR TITLE
add type to ntp servers array

### DIFF
--- a/manifests/rules/ntpd.pp
+++ b/manifests/rules/ntpd.pp
@@ -44,14 +44,14 @@
 #
 # @api private
 class cis_security_hardening::rules::ntpd (
-  Boolean $enforce                    = false,
-  Optional[Array] $ntp_servers,
-  Array $ntp_restrict                 = [],
-  Stdlib::Absolutepath $ntp_driftfile = '/var/lib/ntp/drift',
+  Boolean                        $enforce             = false,
+  Optional[Array[Stdlib::Host]]  $ntp_servers,
+  Array                          $ntp_restrict        = [],
+  Stdlib::Absolutepath           $ntp_driftfile       = '/var/lib/ntp/drift',
   Optional[Stdlib::Absolutepath] $ntp_statsdir,
-  Boolean $ntp_disable_monitor        = true,
-  Boolean $ntp_burst                  = false,
-  Boolean $ntp_service_manage         = true,
+  Boolean                        $ntp_disable_monitor = true,
+  Boolean                        $ntp_burst           = false,
+  Boolean                        $ntp_service_manage  = true,
 ) {
   if $enforce and $facts['os']['name'].downcase() != 'sles' {
     $ntp_default = {


### PR DESCRIPTION
I have added `Stdlib::Host` to the `ntp_servers` array however this is a weird type.  If you try to submit a truncated ipv4 address such as `10.0.0.1.1` it accepts it, however `Stdlib::IP::Address` does not. The advantage of using `Stdlib::Host` is that it will accept fqdn's, which are valid as well as ip addresses in ntpd.conf