### PR TITLE
support puppetlabs-firewall version 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "puppetlabs-firewall",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-reboot",


### PR DESCRIPTION
This change simply adds support for `puppetlabs-firewall` version 8.

Fixes https://github.com/tom-krieger/cis_security_hardening/issues/87