### PR TITLE
Use pam_pwhistory for ubuntu 22.04

### DIFF
--- a/manifests/rules/pam_old_passwords.pp
+++ b/manifests/rules/pam_old_passwords.pp
@@ -124,7 +124,8 @@ class cis_security_hardening::rules::pam_old_passwords (
         }
       }
       'debian', 'suse': {
-        if ($facts['os']['name'].downcase() == 'debian' and $facts['os']['release']['major'] > '10') {
+        if ($facts['os']['name'].downcase() == 'debian' and $facts['os']['release']['major'] > '10') or
+        ($facts['os']['name'].downcase() == 'ubuntu' and $facts['os']['release']['major'] >= '22') {
           Pam { 'pam-common-password-requisite-pwhistory':
             ensure    => present,
             service   => 'common-password',

--- a/spec/classes/rules/pam_old_passwords_spec.rb
+++ b/spec/classes/rules/pam_old_passwords_spec.rb
@@ -118,7 +118,7 @@ describe 'cis_security_hardening::rules::pam_old_passwords' do
               is_expected.not_to contain_pam('pam-password-auth-sufficient')
               is_expected.not_to contain_exec('update authselect config for old passwords')
 
-              if os_facts[:os]['name'].casecmp('debian').zero? && os_facts[:os]['release']['major'] > '10'
+              if os_facts[:os]['name'].casecmp('debian').zero? && os_facts[:os]['release']['major'] > '10' || os_facts[:os]['name'].casecmp('ubuntu').zero? && os_facts[:os]['release']['major'] >= '22'
                 is_expected.to contain_pam('pam-common-password-requisite-pwhistory')
                   .with(
                     'ensure'    => 'present',


### PR DESCRIPTION
Use pam_pwhistory for Ubuntu 22.04 for password history.

Fixes https://github.com/tom-krieger/cis_security_hardening/issues/94