### PR TITLE
Use /etc/gdm3/greeter.dconf-defaults for ubuntu

### DIFF
--- a/lib/facter/cis_security_hardening/facts_ubuntu.rb
+++ b/lib/facter/cis_security_hardening/facts_ubuntu.rb
@@ -17,7 +17,7 @@ def facts_ubuntu(os, distid, release)
   cis_security_hardening[:apparmor] = read_apparmor_data
 
   # get gnome display manager information
-  cis_security_hardening[:gnome_gdm] = File.exist?('/etc/gdm3/greeter.dconf')
+  cis_security_hardening[:gnome_gdm] = File.exist?('/etc/gdm3/greeter.dconf-defaults')
 
   # get iptables config
   cis_security_hardening['iptables'] = read_iptables_rules('4')


### PR DESCRIPTION
Use /etc/gdm3/greeter.dconf-defaults for ubuntu to detect if gnome gdm is in use.  This is how it is on 22.04.

Fixes https://github.com/tom-krieger/cis_security_hardening/issues/100