### PR TITLE
allow params to be set for logrotate class

### DIFF
--- a/manifests/rules/logrotate.pp
+++ b/manifests/rules/logrotate.pp
@@ -35,28 +35,30 @@
 #
 # @api private
 class cis_security_hardening::rules::logrotate (
-  Boolean $enforce      = false,
-  Boolean $dateext      = true,
-  Boolean $compress     = true,
-  Integer $rotate       = 7,
-  String $rotate_every  = 'week',
-  Boolean $ifempty      = true,
-  Boolean $su           = false,
-  String $su_user       = 'root',
-  String $su_group      = 'syslog',
+  Boolean $enforce       = false,
+  Boolean $dateext       = true,
+  Boolean $compress      = true,
+  Boolean $delaycompress = true,
+  Integer $rotate        = 7,
+  String $rotate_every   = 'week',
+  Boolean $ifempty       = true,
+  Boolean $su            = false,
+  String $su_user        = 'root',
+  String $su_group       = 'syslog',
 ) {
   if $enforce {
     class { 'logrotate':
       create_base_rules => false,
       config            => {
-        dateext      => $dateext,
-        compress     => $compress,
-        rotate       => $rotate,
-        rotate_every => $rotate_every,
-        ifempty      => $ifempty,
-        su           => $su,
-        su_user      => $su_user,
-        su_group     => $su_group,
+        dateext       => $dateext,
+        compress      => $compress,
+        delaycompress => $delaycompress,
+        rotate        => $rotate,
+        rotate_every  => $rotate_every,
+        ifempty       => $ifempty,
+        su            => $su,
+        su_user       => $su_user,
+        su_group      => $su_group,
       },
     }
   }

--- a/manifests/rules/logrotate.pp
+++ b/manifests/rules/logrotate.pp
@@ -11,6 +11,18 @@
 #
 # @param enforce
 #    Enforce the rule
+# @param dateext
+#    Use date extension for rotated files.
+# @param compress
+#    Compress rotated files.
+# @param rotate
+#    Number of rotations to keep.
+# @param rotate_every
+#    Frequency of rotation (e.g., 'daily', 'weekly').
+# @param ifempty
+#    Rotate the log file even if it is empty.
+# @param su
+#    Use su directive for logrotate.
 # @param su_user
 #    User for logrotate.
 # @param su_group
@@ -23,19 +35,28 @@
 #
 # @api private
 class cis_security_hardening::rules::logrotate (
-  Boolean $enforce = false,
-  String $su_user  = 'root',
-  String $su_group = 'syslog',
+  Boolean $enforce      = false,
+  Boolean $dateext      = true,
+  Boolean $compress     = true,
+  Integer $rotate       = 7,
+  String $rotate_every  = 'week',
+  Boolean $ifempty      = true,
+  Boolean $su           = false,
+  String $su_user       = 'root',
+  String $su_group      = 'syslog',
 ) {
   if $enforce {
     class { 'logrotate':
       create_base_rules => false,
       config            => {
-        dateext      => true,
-        compress     => true,
-        rotate       => 7,
-        rotate_every => 'week',
-        ifempty      => true,
+        dateext      => $dateext,
+        compress     => $compress,
+        rotate       => $rotate,
+        rotate_every => $rotate_every,
+        ifempty      => $ifempty,
+        su           => $su,
+        su_user      => $su_user,
+        su_group     => $su_group,
       },
     }
   }

--- a/manifests/rules/logrotate.pp
+++ b/manifests/rules/logrotate.pp
@@ -15,6 +15,8 @@
 #    Use date extension for rotated files.
 # @param compress
 #    Compress rotated files.
+# @param delaycompress
+#    Delay compression of rotated files.
 # @param rotate
 #    Number of rotations to keep.
 # @param rotate_every
@@ -38,7 +40,7 @@ class cis_security_hardening::rules::logrotate (
   Boolean $enforce       = false,
   Boolean $dateext       = true,
   Boolean $compress      = true,
-  Boolean $delaycompress = true,
+  Boolean $delaycompress = false,
   Integer $rotate        = 7,
   String $rotate_every   = 'week',
   Boolean $ifempty       = true,

--- a/spec/classes/rules/logrotate_spec.rb
+++ b/spec/classes/rules/logrotate_spec.rb
@@ -31,14 +31,15 @@ describe 'cis_security_hardening::rules::logrotate' do
             is_expected.to create_class('logrotate')
               .with(
                 'config' => {
-                  'dateext'      => true,
-                  'compress'     => true,
-                  'rotate'       => 7,
-                  'rotate_every' => 'week',
-                  'ifempty'      => true,
-                  'su'           => false,
-                  'su_user'      => 'root',
-                  'su_group'     => 'syslog',
+                  'dateext'       => true,
+                  'compress'      => true,
+                  'delaycompress' => true,
+                  'rotate'        => 7,
+                  'rotate_every'  => 'week',
+                  'ifempty'       => true,
+                  'su'            => false,
+                  'su_user'       => 'root',
+                  'su_group'      => 'syslog',
                 },
               )
 

--- a/spec/classes/rules/logrotate_spec.rb
+++ b/spec/classes/rules/logrotate_spec.rb
@@ -33,7 +33,7 @@ describe 'cis_security_hardening::rules::logrotate' do
                 'config' => {
                   'dateext'       => true,
                   'compress'      => true,
-                  'delaycompress' => true,
+                  'delaycompress' => false,
                   'rotate'        => 7,
                   'rotate_every'  => 'week',
                   'ifempty'       => true,

--- a/spec/classes/rules/logrotate_spec.rb
+++ b/spec/classes/rules/logrotate_spec.rb
@@ -36,6 +36,9 @@ describe 'cis_security_hardening::rules::logrotate' do
                   'rotate'       => 7,
                   'rotate_every' => 'week',
                   'ifempty'      => true,
+                  'su'           => false,
+                  'su_user'      => 'root',
+                  'su_group'     => 'syslog',
                 },
               )
 


### PR DESCRIPTION
Adds ability to pass in relevant parameters to puppet-logrotate where they were hardcoded before. In particular, Ubuntu 22.04 needs a `su root adm` line in `logrotate.conf` for log rotation to work properly.