### PR TITLE
Manage systemd-timesyncd package if enforced

### DIFF
--- a/manifests/rules/systemd_timesyncd.pp
+++ b/manifests/rules/systemd_timesyncd.pp
@@ -60,6 +60,10 @@ class cis_security_hardening::rules::systemd_timesyncd (
           ensure => $ensure,
       })
 
+      ensure_packages(['systemd-timesyncd'], {
+          ensure => installed,
+      })
+
       $servers = join($ntp_servers, ' ')
       file_line { 'ntp-timesyncd.conf':
         path               => '/etc/systemd/timesyncd.conf',

--- a/spec/classes/rules/systemd_timesyncd_spec.rb
+++ b/spec/classes/rules/systemd_timesyncd_spec.rb
@@ -70,6 +70,11 @@ describe 'cis_security_hardening::rules::systemd_timesyncd' do
                   )
               end
 
+              is_expected.to contain_package('systemd-timesyncd')
+                .with(
+                  'ensure' => 'installed',
+                )
+
               is_expected.to contain_service('systemd-timesyncd.service')
                 .with(
                   'enable' => true,


### PR DESCRIPTION
Manage the `systemd-timesyncd` if `systemd_timesyncd::enforce` is true. 

Fixes https://github.com/tom-krieger/cis_security_hardening/issues/110