### PR TITLE
Use success=1 for faillock

### DIFF
--- a/files/pam_lockout/debian/common-auth
+++ b/files/pam_lockout/debian/common-auth
@@ -1,6 +1,6 @@
 auth    required                        pam_faillock.so preauth debug
 auth    [success=1 default=ignore]      pam_unix.so nullok
 auth    [default=die]                   pam_faillock.so authfail debug
-auth    sufficient                      pam_faillock.so authsucc debug
+auth    [success=1]                     pam_faillock.so authsucc debug
 auth    requisite                       pam_deny.so
 auth    required                        pam_permit.so

--- a/files/pam_lockout/ubuntu/common-auth
+++ b/files/pam_lockout/ubuntu/common-auth
@@ -1,6 +1,6 @@
 auth    required                        pam_faillock.so preauth debug
 auth    [success=1 default=ignore]      pam_unix.so nullok
 auth    [default=die]                   pam_faillock.so authfail debug
-auth    sufficient                      pam_faillock.so authsucc debug
+auth    [success=1]                     pam_faillock.so authsucc debug
 auth    requisite                       pam_deny.so
 auth    required                        pam_permit.so

--- a/manifests/rules/aide_regular_checks.pp
+++ b/manifests/rules/aide_regular_checks.pp
@@ -86,7 +86,7 @@ class cis_security_hardening::rules::aide_regular_checks (
     } else {
       if ! empty($content) {
         file { '/etc/cron.d/aide.cron':
-          ensure  => absent,
+          ensure => absent,
         }
         file { '/etc/cron.d/aide':
           ensure  => file,


### PR DESCRIPTION
Use `success=1` for the pam faillock line in `common-auth` for debian and ubuntu so that processing continues after a success and things like GNOME keyring automatic unlocking work.

Fixes https://github.com/tom-krieger/cis_security_hardening/issues/114