### PR TITLE
Manage auditd cron output file and fix cron

### DIFF
--- a/manifests/auditd_cron.pp
+++ b/manifests/auditd_cron.pp
@@ -63,5 +63,9 @@ class cis_security_hardening::auditd_cron (
       group   => 'root',
       mode    => '0700',
     }
+
+    file { $output_file:
+      ensure => stdlib::ensure($ensure, file),
+    }
   }
 }

--- a/spec/classes/auditd_cron_spec.rb
+++ b/spec/classes/auditd_cron_spec.rb
@@ -42,6 +42,11 @@ describe 'cis_security_hardening::auditd_cron' do
               'group'   => 'root',
               'mode'    => '0700',
             )
+
+          is_expected.to contain_file('/usr/share/cis_security_hardening/data/auditd_priv_cmds.txt')
+            .with(
+              'ensure' => 'file',
+            )
         end
       end
 
@@ -80,6 +85,11 @@ describe 'cis_security_hardening::auditd_cron' do
               'owner'   => 'root',
               'group'   => 'root',
               'mode'    => '0700',
+            )
+
+          is_expected.to contain_file('/usr/share/cis_security_hardening/data/auditd_priv_cmds.txt')
+            .with(
+              'ensure' => 'absent',
             )
         end
       end

--- a/templates/auditd_priv_cmds.cron.epp
+++ b/templates/auditd_priv_cmds.cron.epp
@@ -1,5 +1,5 @@
 <%- if $cron_repeat == '0' { %>
-<%= $minute %> <%= $hour %> * * * <%= $script %>
+<%= $minute %> <%= $hour %> * * * root <%= $script %>
 <%- } else { %>
-<%= $minute %> <%= $hour %>/<%= $cron_repeat %> * * * <%= $script %>
+<%= $minute %> <%= $hour %>/<%= $cron_repeat %> * * * root <%= $script %>
 <% } %>


### PR DESCRIPTION
Fix the auditd cron file by having it run as the `root` user

Manage the auditd cron output file so we can remove it when `ensure: absent`

Fixes https://github.com/tom-krieger/cis_security_hardening/issues/121